### PR TITLE
Update Localizer.cs

### DIFF
--- a/WinUI3/AK.Toolkit.WinUI3.Localization/Localizer.cs
+++ b/WinUI3/AK.Toolkit.WinUI3.Localization/Localizer.cs
@@ -24,10 +24,11 @@ public partial class Localizer : DependencyObject, ILocalizer
     /// <param name="Content">Windows `Content` Properties</param>
     public void InitializeWindow(FrameworkElement Root, UIElement Content)
     {
-        Instance.RunLocalization(Root);
+        RunLocalizationOnRegisteredRootElements();
+        RunLocalization(Root);
         if (Content is FrameworkElement content)
         {
-            Instance.RegisterRootElement(content);
+            RegisterRootElement(content);
         }
     }
 


### PR DESCRIPTION
Since we are using _**Localizer.Get()**_ we dont need to use _**Instance.Method**_ we can call methods without Instance keyword.
also we can put **RunLocalizationOnRegisteredRootElements** in InitializeWindow Method so we dont need to call this method in **_OnLaunched_** event
