### PR TITLE
Fix issue in the ScrollBarExtensions sample app that annotation's values were not assigned correctly

### DIFF
--- a/Samples/AK.Toolkit.Samples.WinUI3.ScrollBarExtensions/AnnotationsPage.xaml.cs
+++ b/Samples/AK.Toolkit.Samples.WinUI3.ScrollBarExtensions/AnnotationsPage.xaml.cs
@@ -65,7 +65,7 @@ public sealed partial class AnnotationsPage : Page
         Users = new ObservableCollection<User>(
             new Faker<User>()
                 .UseSeed(0)
-                .RuleFor(u => u.Id, f => f.UniqueIndex + 1)
+                .RuleFor(u => u.Id, f => f.IndexFaker + 1)
                 .RuleFor(user => user.FirstName, faker => faker.Name.FirstName())
                 .RuleFor(user => user.LastName, faker => faker.Name.LastName())
                 .RuleFor(user => user.Address, faker => faker.Address.State())


### PR DESCRIPTION
To use User.Id for annotations' value, the User.Id needs to start from "1". The way of creating fake data with "Bogus" wasn't correct. Need to use "IndexFaker" instead of "UniqueIndex".